### PR TITLE
Fixed an issue where video's could not be watched twice in a row.

### DIFF
--- a/jwplayer-appletv-web-app/js/views/ItemDetail.js
+++ b/jwplayer-appletv-web-app/js/views/ItemDetail.js
@@ -19,10 +19,6 @@ ViewManager.registerView("ItemDetail", function(doc) {
 
   var media_id = doc.firstChild.getAttribute("data-media-id");
   var item = MEDIA_ITEMS[media_id];
-  var player = Playback;
-  var playlist = new Playlist();
-  playlist.push(item);
-  player.load(playlist);
 
   var related_id = doc.firstChild.getAttribute("data-related-playlist")
   if (related_id != "undefined") {
@@ -36,7 +32,12 @@ ViewManager.registerView("ItemDetail", function(doc) {
   }
 
   var playButton = doc.getElementById("play-button");
-  playButton.addEventListener("select", player.play);
+  playButton.addEventListener("select", function() {
+    var playlist = new Playlist();
+    playlist.push(item);
+    Playback.load(playlist);
+    Playback.play();
+  });
 
   function showRelated() {
     loader.loadFragment("templates/ListItem.tvml", templateLoaded, false);


### PR DESCRIPTION
This PR fixes the following issue: 

When an item completes playback and the user is taken back to the ItemDetail screen, and hits play again, the playback won't start because there is no playlist containing a `MediaItem` loaded in to the player.

Steps to reproduce:
- Watch a video
- When the video completed playback, hit the "Play video" button again
- A black screen with a loading spinner will be displayed because there is no media loaded into the player.