### PR TITLE
Show long descriptions

### DIFF
--- a/jwplayer-appletv-web-app/js/application.js
+++ b/jwplayer-appletv-web-app/js/application.js
@@ -84,6 +84,4 @@ function showAlert(alertTitle, alertText) {
 
   var alertDoc = domParser.parseFromString(alertTVML, "application/xml");
   navigationDocument.pushDocument(alertDoc);
-
-  throw (alertText);
 }

--- a/jwplayer-appletv-web-app/js/views/ItemDetail.js
+++ b/jwplayer-appletv-web-app/js/views/ItemDetail.js
@@ -31,6 +31,10 @@ ViewManager.registerView("ItemDetail", function(doc) {
     description.textContent = "No description";
   }
 
+  description.addEventListener("select", function() {
+    showAlert(item.title, item.description);
+  });
+
   var playButton = doc.getElementById("play-button");
   playButton.addEventListener("select", function() {
     var playlist = new Playlist();

--- a/jwplayer-appletv-web-app/js/views/ItemDetail.js
+++ b/jwplayer-appletv-web-app/js/views/ItemDetail.js
@@ -15,10 +15,12 @@
 **/
 
 ViewManager.registerView("ItemDetail", function(doc) {
-  var loader = new TemplateLoader(doc);
+  var self = this;
+
+  var loader = new TemplateLoader(doc, this);
 
   var media_id = doc.firstChild.getAttribute("data-media-id");
-  var item = MEDIA_ITEMS[media_id];
+  self.item = MEDIA_ITEMS[media_id];
 
   var related_id = doc.firstChild.getAttribute("data-related-playlist")
   if (related_id != "undefined") {
@@ -32,13 +34,15 @@ ViewManager.registerView("ItemDetail", function(doc) {
   }
 
   description.addEventListener("select", function() {
-    showAlert(item.title, item.description);
+    loader.load("templates/ItemDescription.tvml", function(descriptionDoc) {
+      navigationDocument.pushDocument(descriptionDoc);
+    });
   });
 
   var playButton = doc.getElementById("play-button");
   playButton.addEventListener("select", function() {
     var playlist = new Playlist();
-    playlist.push(item);
+    playlist.push(self.item);
     Playback.load(playlist);
     Playback.play();
   });

--- a/jwplayer-appletv-web-app/templates/ItemDescription.tvml
+++ b/jwplayer-appletv-web-app/templates/ItemDescription.tvml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<document>
+  <descriptiveAlertTemplate>
+    <title>${he.encode(this.item.title)}</title>
+    <description allowsZooming="true">${he.encode(this.item.description)}</description>
+  </descriptiveAlertTemplate>
+</document>


### PR DESCRIPTION
Currently, long descriptions are truncated, but the `allowzoom` attribute on the `<description>` tag allows the user to click on the description, which doesn't do anything.

This will show a simple alert modal containing the title of the item along with the full description text.