### PR TITLE
Update AppDelegate.swift

### DIFF
--- a/jwplayer-appletv-tvos-app/jwplayer-for-tv/AppDelegate.swift
+++ b/jwplayer-appletv-tvos-app/jwplayer-for-tv/AppDelegate.swift
@@ -25,8 +25,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, TVApplicationControllerDe
 
     // Uncomment the following line to debug
     // static let TVBaseURL = "http://localhost/appletv/jwplayer-appletv-web-app"
-    static let TVBaseURL = "https://tvos.jwpsrv.com/current"
-    static let TVConfigURL = "https://tvos.jwpsrv.com/resources/configs"
+    static let TVBaseURL = "https://tvos.jwpsrv.com"
+    static let TVConfigURL = "\(AppDelegate.TVBaseURL)/resources/configs"
     static let TVBootURL = "\(AppDelegate.TVBaseURL)/js/application.js"
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {


### PR DESCRIPTION
removed /current from line 28. v1.0 doesn't use the versioned app/config scheme yet.